### PR TITLE
Add some missing functionality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ fn result_ptr_mut<T>(val: *mut T) -> Result<*mut T, BlkidError> {
 
 impl BlkId {
     pub fn new(file: &Path) -> Result<BlkId, BlkidError> {
-        let path = try!(CString::new(file.as_os_str().to_string_lossy().as_ref()));
+        let path = CString::new(file.as_os_str().to_string_lossy().as_ref())?;
         unsafe {
             // pub fn blkid_do_probe(pr: blkid_probe) -> ::std::os::raw::c_int;
             // pub fn blkid_do_safeprobe(pr: blkid_probe) -> ::std::os::raw::c_int;
@@ -153,7 +153,7 @@ impl BlkId {
         Ok(())
     }
     pub fn lookup_value(&self, name: &str) -> Result<String, BlkidError> {
-        let name = try!(CString::new(name));
+        let name = CString::new(name)?;
         let mut data_ptr: *const ::libc::c_char = ptr::null();
         let mut len = 0;
         unsafe {
@@ -167,7 +167,7 @@ impl BlkId {
         }
     }
     pub fn has_value(&self, name: &str) -> Result<bool, BlkidError> {
-        let name = try!(CString::new(name));
+        let name = CString::new(name)?;
 
         unsafe {
             let ret_code = blkid_probe_has_value(self.probe, name.as_ptr());
@@ -253,7 +253,7 @@ impl BlkId {
         unsafe { Ok(blkid_probe_get_fd(self.probe)) }
     }
     pub fn known_fstype(&self, fstype: &str) -> Result<bool, BlkidError> {
-        let fstype = try!(CString::new(fstype));
+        let fstype = CString::new(fstype)?;
         unsafe {
             let ret_code = blkid_known_fstype(fstype.as_ptr());
             match ret_code {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,6 +380,31 @@ impl BlkId {
         }
         Ok(&self)
     }
+
+    /// Enables the superblocks probing for non-binary interface.
+    pub fn enable_superblocks(&self) -> Result<(&Self), BlkidError> {
+        unsafe {
+            let ret_code = blkid_probe_enable_superblocks(self.probe, 1);
+            if ret_code < 0 {
+                return Err(BlkidError::new(get_error()));
+            }
+        }
+        Ok(&self)
+    }
+
+    /// Sets probing flags to the superblocks prober. This method is optional, the default
+    /// are BLKID_SUBLKS_DEFAULTS flags.
+    /// flags are BLKID_SUBLKS_* flags
+    pub fn set_superblock_flags(&self, flags: u32) -> Result<&Self, BlkidError> {
+        unsafe {
+            let ret_code = blkid_probe_set_superblocks_flags(self.probe, flags as i32);
+            if ret_code < 0 {
+                return Err(BlkidError::new(get_error()));
+            }
+        }
+        Ok(&self)
+    }
+
     // pub fn blkid_probe_get_partitions(pr: blkid_probe) -> blkid_partlist;
     // pub fn blkid_partlist_numof_partitions(ls: blkid_partlist)
     // -> ::std::os::raw::c_int;
@@ -495,12 +520,6 @@ pub mod tag;
 // name:
 // mut *const ::std::os::raw::c_char,
 // usage: *mut ::std::os::raw::c_int)
-// -> ::std::os::raw::c_int;
-// pub fn blkid_probe_enable_superblocks(pr: blkid_probe,
-// enable: ::std::os::raw::c_int)
-// -> ::std::os::raw::c_int;
-// pub fn blkid_probe_set_superblocks_flags(pr: blkid_probe,
-// flags: ::std::os::raw::c_int)
 // -> ::std::os::raw::c_int;
 // pub fn blkid_probe_reset_superblocks_filter(pr: blkid_probe)
 // -> ::std::os::raw::c_int;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ impl BlkId {
             // pub fn blkid_do_safeprobe(pr: blkid_probe) -> ::std::os::raw::c_int;
             // pub fn blkid_do_fullprobe(pr: blkid_probe) -> ::std::os::raw::c_int;
             let probe = result_ptr_mut(blkid_new_probe_from_filename(path.as_ptr()))?;
-            Ok(BlkId { probe: probe })
+            Ok(BlkId { probe })
         }
     }
     /// Calls probing functions in all enabled chains. The superblocks chain is enabled by

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,6 +330,28 @@ impl BlkId {
         unsafe { blkid_topology_get_physical_sector_size(tp) }
     }
 
+    /// Enables the partitions probing for non-binary interface.
+    pub fn enable_partitions(&self) -> Result<&Self, BlkidError> {
+        unsafe {
+            let ret_code = blkid_probe_enable_partitions(self.probe, 1);
+            if ret_code < 0 {
+                return Err(BlkidError::new(get_error()));
+            }
+        }
+        Ok(self)
+    }
+
+    /// Sets probing flags to the partitions prober. This method is optional.
+    /// BLKID_PARTS_* flags
+    pub fn set_partition_flags(&self, flags: u32) -> Result<(&Self), BlkidError> {
+        unsafe {
+            let ret_code = blkid_probe_set_partitions_flags(self.probe, flags as i32);
+            if ret_code < 0 {
+                return Err(BlkidError::new(get_error()));
+            }
+        }
+        Ok(&self)
+    }
     // pub fn blkid_probe_get_partitions(pr: blkid_probe) -> blkid_partlist;
     // pub fn blkid_partlist_numof_partitions(ls: blkid_partlist)
     // -> ::std::os::raw::c_int;
@@ -467,9 +489,6 @@ pub mod tag;
 // -> ::std::os::raw::c_int;
 // pub fn blkid_known_pttype(pttype: *const ::std::os::raw::c_char)
 // -> ::std::os::raw::c_int;
-// pub fn blkid_probe_enable_partitions(pr: blkid_probe,
-// enable: ::std::os::raw::c_int)
-// -> ::std::os::raw::c_int;
 // pub fn blkid_probe_reset_partitions_filter(pr: blkid_probe)
 // -> ::std::os::raw::c_int;
 // pub fn blkid_probe_invert_partitions_filter(pr: blkid_probe)
@@ -478,9 +497,6 @@ pub mod tag;
 // flag: ::std::os::raw::c_int,
 // names:
 // mut *mut ::std::os::raw::c_char)
-// -> ::std::os::raw::c_int;
-// pub fn blkid_probe_set_partitions_flags(pr: blkid_probe,
-// flags: ::std::os::raw::c_int)
 // -> ::std::os::raw::c_int;
 // pub fn blkid_probe_get_value(pr: blkid_probe,
 // num: ::std::os::raw::c_int,


### PR DESCRIPTION
Added some functionality that is needed for our usage.  One open questions is the return value for `do_safe_probe`.  Is it sufficient to use the existing integer return values or introduce an enumeration?  I can see pros/cons for each approach.