### PR TITLE
Add the function get_tag_value()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,7 +240,7 @@ impl BlkId {
     }
 
     // https://github.com/karelzak/util-linux/blob/master/Documentation/blkid.txt
-    /// Retrieve the value of a specific attribute for a particualr device.  
+    /// Retrieve the value of a specific attribute for a particular device.  
     /// This can be used to determine attributes such as TYPE, UUID, LABEL, and PARTUUID
     /// Returns empty string if the requested attribute is not set for a particular device
     pub fn get_tag_value(&self, tagname: &str, devname: &Path) -> Result<String, BlkidError> {
@@ -250,12 +250,10 @@ impl BlkId {
         unsafe {
             let ret_value: *mut ::libc::c_char =
                 blkid_get_tag_value(cache, tag_name.as_ptr(), dev_name.as_ptr());
-            println!("This ran");
             if ret_value.is_null() {
                 return Ok("".to_string());
             }
             let data_value = CString::from_raw(ret_value);
-            println!("Converting...");
             Ok(data_value.into_string()?)
         }
     }


### PR DESCRIPTION
get_tag_value retrieves a specific attribute for a particular device without probing.  It returns an empty string if the device does not have the requested attribute (Sometimes do_probe(), do_safe_probe() return nothing or do not get the UUID or PARTUUID no matter how many times you probe and check for the attribute, not sure why even if you enable partitions, superblocks, and topology or set different flags)

https://github.com/karelzak/util-linux/blob/master/Documentation/blkid.txt 