### PR TITLE
Make crate more flexible to different versions of lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ libc = "^0.2"
 strum = "^0.23"
 strum_macros = "^0.23"
 thiserror = "^1.0"
+
+[build-dependencies]
+pkg-config = "^0.3"

--- a/README.md
+++ b/README.md
@@ -2,5 +2,9 @@
 Rust blkid safe interface
 [![Build Status](https://travis-ci.org/cholcombe973/blkid.svg?branch=master)](https://travis-ci.org/cholcombe973/blkid)
 
+## Supported versions of `libblkid`
+This crate requires at least `2.21.0` version of `libblkid`.
+The last implemented version is `2.37.2`.
+
 ## Contributing
-Several blkid function wrappers still need writing.  Feel free to fork and PR back.  
+Several blkid function wrappers still need writing. Feel free to fork and PR back.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,37 @@
+const LIB_NAME: &str = "blkid";
+const BLKID_MIN_REQ_VERSION: &str = "2.21.0";
+/// MIN numbers of versions where were added new functionality
+const BLKID_CHANGED_MIN_VERSIONS: &[usize] = &[23, 24, 25, 30, 31, 36, 37];
+
+fn main() {
+    let libblkid = pkg_config::Config::new()
+        .atleast_version(BLKID_MIN_REQ_VERSION)
+        .probe(LIB_NAME)
+        .expect("Failed to find minimal required version of library");
+
+    // Take a MIN version from: `MAJ.MIN.PATCH`
+    let min_num = libblkid
+        .version
+        .split_terminator('.')
+        .nth(1)
+        .expect("Failed to find MIN number of version");
+    // Parse version to figure out what features should to be enabled
+    let min_num: usize = min_num
+        .parse()
+        .expect("Failed to parse MIN number of version");
+
+    // Find the index of the last changed version
+    let idx = BLKID_CHANGED_MIN_VERSIONS.iter().position(|v| v > &min_num);
+
+    if let Some(idx) = idx {
+        // If we have some index this means not all features need to be enabled
+        for min_num in &BLKID_CHANGED_MIN_VERSIONS[..idx] {
+            println!("cargo:rustc-cfg={}=\"2.{}\"", LIB_NAME, min_num);
+        }
+    } else {
+        // In this case we just enable all features
+        for min_num in BLKID_CHANGED_MIN_VERSIONS {
+            println!("cargo:rustc-cfg={}=\"2.{}\"", LIB_NAME, min_num);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ bitflags! {
         /// Define SBMAGIC and SBMAGIC_OFFSET
         const MAGIC     = 1 << 9;
         /// Allow a bad checksum
+        #[cfg(blkid = "2.24")]
         const BADCSUM   = 1 << 10;
         /// Default flags
         const DEFAULT   = Self::LABEL.bits | Self::UUID.bits | Self::TYPE.bits | Self::SECTYPE.bits;

--- a/src/part_list.rs
+++ b/src/part_list.rs
@@ -20,6 +20,7 @@ impl PartList {
     ///
     /// This does not assume any order of the input blkid_partlist. And correctly handles "out of
     /// order" partition tables. partition N is located after partition N+1 on the disk.
+    #[cfg(blkid = "2.25")]
     pub fn get_partition_by_parno(&self, partno: i32) -> BlkIdResult<Partition> {
         unsafe { c_result(blkid_partlist_get_partition_by_partno(self.0, partno)).map(Partition) }
     }

--- a/src/part_table.rs
+++ b/src/part_table.rs
@@ -11,6 +11,7 @@ impl PartTable {
     /// Returns partition table ID (for example GPT disk UUID).
     ///
     /// The ID is GPT disk UUID or DOS disk ID (in hex format).
+    #[cfg(blkid = "2.23")]
     pub fn get_id(&self) -> Option<String> {
         let ptr = unsafe { blkid_parttable_get_id(self.0) };
         if ptr.is_null() {

--- a/src/prober.rs
+++ b/src/prober.rs
@@ -266,13 +266,14 @@ impl Prober {
         unsafe { blkid_probe_get_sectorsize(self.0) }
     }
 
-    // /// Set logical sector size.
-    // ///
-    // /// Note that [`Self::set_device`] resets this setting. Use it after [`Self::set_device`] and
-    // /// before any probing call.
-    // pub fn set_sector_size(&self, size: u32) -> BlkIdResult<()> {
-    //     unsafe { c_result(blkid_probe_set_sectorsize(self.0, size)).map(|_| ()) }
-    // }
+    /// Set logical sector size.
+    ///
+    /// Note that [`Self::set_device`] resets this setting. Use it after [`Self::set_device`] and
+    /// before any probing call.
+    #[cfg(blkid = "2.30")]
+    pub fn set_sector_size(&self, size: u32) -> BlkIdResult<()> {
+        unsafe { c_result(blkid_probe_set_sectorsize(self.0, size)).map(|_| ()) }
+    }
 
     /// 512-byte sector count
     pub fn get_sectors(&self) -> BlkIdResult<i64> {
@@ -300,24 +301,26 @@ impl Prober {
         unsafe { blkid_probe_is_wholedisk(self.0) == 1 }
     }
 
-    // /// Modifies in-memory cached data from the device. The specified range is zeroized.
-    // /// This is usable together with [`Self::step_back`]. The next [`Self::do_probe`] will not see
-    // /// specified area.
-    // ///
-    // /// Note that this is usable for already (by library) read data, and this function is not a way
-    // /// how to hide any large areas on your device.
-    // ///
-    // /// The [`Self::reset_buffers`] reverts all.
-    // pub fn hide_range(&self, offset: u64, size: u64) -> BlkIdResult<()> {
-    //     unsafe { c_result(blkid_probe_hide_range(self.0, offset, size)).map(|_| ()) }
-    // }
+    /// Modifies in-memory cached data from the device. The specified range is zeroized.
+    /// This is usable together with [`Self::step_back`]. The next [`Self::do_probe`] will not see
+    /// specified area.
+    ///
+    /// Note that this is usable for already (by library) read data, and this function is not a way
+    /// how to hide any large areas on your device.
+    ///
+    /// The [`Self::reset_buffers`] reverts all.
+    #[cfg(blkid = "2.31")]
+    pub fn hide_range(&self, offset: u64, size: u64) -> BlkIdResult<()> {
+        unsafe { c_result(blkid_probe_hide_range(self.0, offset, size)).map(|_| ()) }
+    }
 
-    // /// Reuse all already read buffers from the device. The buffers may be modified by
-    // /// [`Self::hide_range`]. This resets and free all cached buffers. The next [`Self::do_probe`]
-    // /// will read all data from the device.
-    // pub fn reset_buffers(&self) -> BlkIdResult<()> {
-    //     unsafe { c_result(blkid_probe_reset_buffers(self.0)).map(|_| ()) }
-    // }
+    /// Reuse all already read buffers from the device. The buffers may be modified by
+    /// [`Self::hide_range`]. This resets and free all cached buffers. The next [`Self::do_probe`]
+    /// will read all data from the device.
+    #[cfg(blkid = "2.31")]
+    pub fn reset_buffers(&self) -> BlkIdResult<()> {
+        unsafe { c_result(blkid_probe_reset_buffers(self.0)).map(|_| ()) }
+    }
 
     /// This function move pointer to the probing chain one step back - it means that the
     /// previously used probing function will be called again in the next [`Self::do_probe`] call.
@@ -334,6 +337,7 @@ impl Prober {
     /// let prober = Prober::new_from_filename("/dev/sda");
     /// TODO: coplete this example
     /// ```
+    #[cfg(blkid = "2.23")]
     pub fn step_back(&self) -> BlkIdResult<()> {
         unsafe { c_result(blkid_probe_step_back(self.0)).map(|_| ()) }
     }
@@ -420,13 +424,14 @@ impl Prober {
         Ok(unsafe { blkid_known_pttype(pttype.as_ptr()) == 1 })
     }
 
-    // /// Returns name of a supported partition.
-    // pub fn partitions_get_name(idx: u64) -> BlkIdResult<String> {
-    //     let mut name: *const ::libc::c_char = ptr::null();
-    //     unsafe { c_result(blkid_partitions_get_name(idx, &mut name)) }?;
-    //     let name = unsafe { CStr::from_ptr(name).to_str()?.to_owned() };
-    //     Ok(name)
-    // }
+    /// Returns name of a supported partition.
+    #[cfg(blkid = "2.30")]
+    pub fn partitions_get_name(idx: u64) -> BlkIdResult<String> {
+        let mut name: *const ::libc::c_char = ptr::null();
+        unsafe { c_result(blkid_partitions_get_name(idx, &mut name)) }?;
+        let name = unsafe { CStr::from_ptr(name).to_str()?.to_owned() };
+        Ok(name)
+    }
 
     /// Returns [`PartList`] object.
     ///
@@ -463,20 +468,20 @@ impl Prober {
         unsafe { c_result(blkid_probe_get_topology(self.0)).map(Topology) }
     }
 
-    // TODO: uncomments this when it will be possible
-    // Sets extra hint for low-level prober. If the hint is set by NAME=value notation than value
-    // is ignored. The [`Self::set_device`] and [`Self::reset_probe`] resets all hints.
-    //
-    // The hints are optional way how to force libblkid probing functions to check for example
-    // another location.
-    // pub fn set_hint(&self, hint_name: &str, offset: u64) -> BlkIdResult<()> {
-    //     let name = CString::new(hint_name)?;
-    //     unsafe { c_result(blkid_probe_set_hint(self.0, name.as_ptr(), offset)).map(|_| ()) }
-    // }
+    /// Sets extra hint for low-level prober. If the hint is set by NAME=value notation than value
+    /// is ignored. The [`Self::set_device`] and [`Self::reset_probe`] resets all hints.
+    ///
+    /// The hints are optional way how to force libblkid probing functions to check for example
+    /// another location.
+    #[cfg(blkid = "2.37")]
+    pub fn set_hint(&self, hint_name: &str, offset: u64) -> BlkIdResult<()> {
+        let name = CString::new(hint_name)?;
+        unsafe { c_result(blkid_probe_set_hint(self.0, name.as_ptr(), offset)).map(|_| ()) }
+    }
 
-    // TODO: uncomments this when it will be possible
-    // Removes all previously defined probing hints. See also [`Self::set_hint`]
-    // pub fn reset_hints(&self) -> BlkIdResult<()> {
-    //    unsafe { c_result(blkid_probe_reset_hints(self.0)).map(|_| ()) }
-    // }
+    /// Removes all previously defined probing hints. See also [`Self::set_hint`]
+    #[cfg(blkid = "2.37")]
+    pub fn reset_hints(&self) {
+        unsafe { blkid_probe_reset_hints(self.0) }
+    }
 }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -29,9 +29,9 @@ impl Topology {
         unsafe { blkid_topology_get_physical_sector_size(self.0) }
     }
 
-    // TODO: uncomment this when will be available
-    // /// Returns `true` if dax is supported
-    // pub fn dax(&self) -> bool {
-    //     unsafe { blkid_topogy_get_dax(self.0) == 1 }
-    // }
+    /// Returns `true` if dax is supported
+    #[cfg(blkid = "2.36")]
+    pub fn dax(&self) -> bool {
+        unsafe { blkid_topology_get_dax(self.0) == 1 }
+    }
 }


### PR DESCRIPTION
Use `pkg_config` crate to determine installed version of `libblkid`
library in system.
Enable compile features depend on found version of library.
At now this crate requires at least `2.21.0` version of lib and has
implemented functionality of `2.37.2`.

Closes #8