### PR TITLE
Fix compilation for 32-bit architectures

### DIFF
--- a/src/prober.rs
+++ b/src/prober.rs
@@ -426,9 +426,9 @@ impl Prober {
 
     /// Returns name of a supported partition.
     #[cfg(blkid = "2.30")]
-    pub fn partitions_get_name(idx: u64) -> BlkIdResult<String> {
+    pub fn partitions_get_name(idx: usize) -> BlkIdResult<String> {
         let mut name: *const ::libc::c_char = ptr::null();
-        unsafe { c_result(blkid_partitions_get_name(idx, &mut name)) }?;
+        unsafe { c_result(blkid_partitions_get_name(idx.try_into().unwrap(), &mut name)) }?;
         let name = unsafe { CStr::from_ptr(name).to_str()?.to_owned() };
         Ok(name)
     }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -6,27 +6,27 @@ pub struct Topology(pub(crate) blkid_topology);
 impl Topology {
     /// Alignment offset in bytes or 0.
     pub fn alignment_offset(&self) -> u64 {
-        unsafe { blkid_topology_get_alignment_offset(self.0) }
+        unsafe { blkid_topology_get_alignment_offset(self.0) }.try_into().unwrap()
     }
 
     /// Minimum io size in bytes or 0.
     pub fn minimum_io_size(&self) -> u64 {
-        unsafe { blkid_topology_get_minimum_io_size(self.0) }
+        unsafe { blkid_topology_get_minimum_io_size(self.0) }.try_into().unwrap()
     }
 
     /// Optimal io size in bytes or 0.
     pub fn optimal_io_size(&self) -> u64 {
-        unsafe { blkid_topology_get_optimal_io_size(self.0) }
+        unsafe { blkid_topology_get_optimal_io_size(self.0) }.try_into().unwrap()
     }
 
     /// Logical sector size (BLKSSZGET ioctl) in bytes or 0.
     pub fn logical_sector_size(&self) -> u64 {
-        unsafe { blkid_topology_get_logical_sector_size(self.0) }
+        unsafe { blkid_topology_get_logical_sector_size(self.0) }.try_into().unwrap()
     }
 
     /// Logical sector size (BLKSSZGET ioctl) in bytes or 0.
     pub fn physical_sector_size(&self) -> u64 {
-        unsafe { blkid_topology_get_physical_sector_size(self.0) }
+        unsafe { blkid_topology_get_physical_sector_size(self.0) }.try_into().unwrap()
     }
 
     /// Returns `true` if dax is supported


### PR DESCRIPTION
The topology functions return `unsigned long`, so we can keep the API simple by just converting 32-bit values to `u64`.

For `partitions_get_name()`, which takes a `size_t`, converting a `u64` on 32-bit architectures could fail, so it's better to adjust the API to try to ensure overly large values can't be passed.

Technically, `usize` is `uintptr_t`, not `size_t`, and `uintptr_t` can be bigger than `size_t`, so it's possible that the architecture could allow overly big values to be passed to `partitions_get_name()`, but I'm not aware of any Linux architectures where that's the case, and even if it was, it would just result in a panic if too big a value was passed. It's worth it to expose usize in the high-level API, rather than `libc::size_t`.