### PR TITLE
Fix review findings and improve FFI error handling

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: install packages
-      run: sudo apt install -y libblkid-dev
+      run: sudo apt-get update && sudo apt-get install -y libblkid-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -64,7 +64,7 @@ impl Cache {
     }
 
     /// Returns iterator over all devices are found by probe
-    pub fn devs(&self) -> Devs<'_> {
+    pub fn devs(&self) -> BlkIdResult<Devs<'_>> {
         Devs::new(self)
     }
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -11,7 +11,6 @@ use std::{
     path::Path,
     ptr,
 };
-extern crate libc;
 
 #[derive(Debug)]
 pub struct Cache(pub(crate) blkid_cache);
@@ -27,7 +26,7 @@ impl Cache {
     /// environment variable `BLKID_FILE`
     pub fn new() -> BlkIdResult<Self> {
         let mut cache: blkid_cache = ptr::null_mut();
-        unsafe { c_result(blkid_get_cache(&mut cache, ptr::null())) }?;
+        unsafe { c_result(blkid_get_cache(&mut cache, ptr::null()), "blkid_get_cache") }?;
         Ok(Self(cache))
     }
 
@@ -35,18 +34,18 @@ impl Cache {
     pub fn new_by_path<P: AsRef<Path>>(path: P) -> BlkIdResult<Self> {
         let mut cache: blkid_cache = ptr::null_mut();
         let path = path_to_cstring(path)?;
-        unsafe { c_result(blkid_get_cache(&mut cache, path.as_ptr())) }?;
+        unsafe { c_result(blkid_get_cache(&mut cache, path.as_ptr()), "blkid_get_cache") }?;
         Ok(Self(cache))
     }
 
     /// Probes all block devices
     pub fn probe_all(&self) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_all(self.0)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_all(self.0), "blkid_probe_all").map(|_| ()) }
     }
 
     /// Probes all new block devices
     pub fn prob_all_new(&self) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_all_new(self.0)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_all_new(self.0), "blkid_probe_all_new").map(|_| ()) }
     }
 
     /// The `libblkid` probing is based on devices from `/proc/partitions` by default. This file
@@ -61,7 +60,7 @@ impl Cache {
     ///
     /// Devices which were detected by this function won't be written to `blkid.tab` cache file
     pub fn probe_all_removable(&self) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_all_removable(self.0)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_all_removable(self.0), "blkid_probe_all_removable").map(|_| ()) }
     }
 
     /// Returns iterator over all devices are found by probe
@@ -75,7 +74,7 @@ impl Cache {
     /// then create an empty device entry
     pub fn get_dev(&self, name: &str, flags: GetDevFlags) -> BlkIdResult<Dev<'_>> {
         let devname = CString::new(name)?;
-        let dev = unsafe { c_result(blkid_get_dev(self.0, devname.as_ptr(), flags.bits())) }?;
+        let dev = unsafe { c_result(blkid_get_dev(self.0, devname.as_ptr(), flags.bits()), "blkid_get_dev") }?;
         Ok(Dev::new(dev))
     }
 
@@ -105,6 +104,7 @@ impl Cache {
             Ok(None)
         } else {
             let value = unsafe { CStr::from_ptr(ptr).to_str()?.to_owned() };
+            unsafe { libc::free(ptr as *mut _) };
             Ok(Some(value))
         }
     }
@@ -119,8 +119,7 @@ impl Cache {
     pub fn evaluate_tag(&self, token: &str, value: &str) -> Option<String> {
         let token = CString::new(token).ok()?;
         let value = CString::new(value).ok()?;
-        let mut cache = self.0;
-        let ptr = unsafe { blkid_evaluate_tag(token.as_ptr(), value.as_ptr(), &mut cache) };
+        let ptr = unsafe { blkid_evaluate_tag(token.as_ptr(), value.as_ptr(), ptr::null_mut()) };
         if ptr.is_null() {
             None
         } else {
@@ -134,8 +133,7 @@ impl Cache {
     /// the devname if found.
     pub fn evaluate_spec(&self, spec: &str) -> Option<String> {
         let spec = CString::new(spec).ok()?;
-        let mut cache = self.0;
-        let ptr = unsafe { blkid_evaluate_spec(spec.as_ptr(), &mut cache) };
+        let ptr = unsafe { blkid_evaluate_spec(spec.as_ptr(), ptr::null_mut()) };
         if ptr.is_null() {
             None
         } else {
@@ -147,17 +145,20 @@ impl Cache {
 
     /// Returns the string of the device identified by a token (e.g. token="LABEL",
     /// value="root"), or by a device name if token is a device path and value is `None`.
-    pub fn get_devname(&self, token: &str, value: Option<&str>) -> Option<String> {
-        let token = CString::new(token).ok()?;
-        let value_c = value.map(|v| CString::new(v).ok()).flatten();
+    pub fn get_devname(&self, token: &str, value: Option<&str>) -> BlkIdResult<Option<String>> {
+        let token = CString::new(token)?;
+        let value_c = match value {
+            Some(v) => Some(CString::new(v)?),
+            None => None,
+        };
         let value_ptr = value_c.as_ref().map_or(ptr::null(), |c| c.as_ptr());
         let ptr = unsafe { blkid_get_devname(self.0, token.as_ptr(), value_ptr) };
         if ptr.is_null() {
-            None
+            Ok(None)
         } else {
-            let s = unsafe { CStr::from_ptr(ptr).to_str().ok()?.to_owned() };
+            let s = unsafe { CStr::from_ptr(ptr).to_str()?.to_owned() };
             unsafe { libc::free(ptr as *mut _) };
-            Some(s)
+            Ok(Some(s))
         }
     }
 }

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -52,7 +52,7 @@ impl<'a> Devs<'a> {
         let s_type = CString::new(search_type)?;
         let s_value = CString::new(search_value)?;
         unsafe {
-            c_result(blkid_dev_set_search(self.iter, s_type.as_ptr(), s_value.as_ptr()))
+            c_result(blkid_dev_set_search(self.iter, s_type.as_ptr(), s_value.as_ptr()), "blkid_dev_set_search")
                 .map(|_| ())
         }
     }

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -1,4 +1,4 @@
-use crate::{cache::Cache, error::c_result, tag::Tags, BlkIdResult};
+use crate::{cache::Cache, error::{c_result, BlkIdError}, tag::Tags, BlkIdResult};
 use bitflags::bitflags;
 use blkid_sys::*;
 use std::{
@@ -37,13 +37,18 @@ impl<'a> Iterator for Devs<'a> {
 
 impl<'a> Devs<'a> {
     /// Creates wrapper around device
-    pub fn new(cache: &'a Cache) -> Devs<'a> {
+    pub fn new(cache: &'a Cache) -> BlkIdResult<Devs<'a>> {
         let iter = unsafe { blkid_dev_iterate_begin(cache.0) };
-        assert_ne!(iter, ptr::null_mut());
-        Devs {
+        if iter.is_null() {
+            return Err(BlkIdError::FfiError {
+                func: "blkid_dev_iterate_begin",
+                errno: std::io::Error::last_os_error(),
+            });
+        }
+        Ok(Devs {
             iter,
             _marker: PhantomData,
-        }
+        })
     }
 
     /// Set search filter for the device iterator. Only devices matching the

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,15 +13,21 @@ pub enum BlkIdError {
 
     #[error(transparent)]
     Io(#[from] io::Error),
+
+    #[error("{func}: {errno}")]
+    FfiError { func: &'static str, errno: io::Error },
 }
 
 pub(crate) trait RawResult: Copy {
     fn is_error(self) -> bool;
 }
 
-pub(crate) fn c_result<T: RawResult>(value: T) -> BlkIdResult<T> {
+pub(crate) fn c_result<T: RawResult>(value: T, func: &'static str) -> BlkIdResult<T> {
     if value.is_error() {
-        Err(BlkIdError::Io(std::io::Error::last_os_error()))
+        Err(BlkIdError::FfiError {
+            func,
+            errno: io::Error::last_os_error(),
+        })
     } else {
         Ok(value)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ bitflags! {
 }
 
 /// Returns the device name for the given device number. Returns `None` if not found.
-pub fn devno_to_devname(devno: u64) -> Option<String> {
+pub fn devno_to_devname(devno: libc::dev_t) -> Option<String> {
     let ptr = unsafe { blkid_devno_to_devname(devno) };
     if ptr.is_null() {
         None
@@ -99,16 +99,19 @@ pub fn devno_to_devname(devno: u64) -> Option<String> {
 
 /// Converts a device number to its whole-disk device name and device number.
 /// Returns `(disk_name, disk_devno)`.
-pub fn devno_to_wholedisk(devno: u64) -> BlkIdResult<(String, u64)> {
-    let mut buf = vec![0u8; 128];
-    let mut diskdevno: u64 = 0;
+pub fn devno_to_wholedisk(devno: libc::dev_t) -> BlkIdResult<(String, libc::dev_t)> {
+    let mut buf = vec![0u8; 4096];
+    let mut diskdevno: libc::dev_t = 0;
     unsafe {
-        c_result(blkid_devno_to_wholedisk(
-            devno,
-            buf.as_mut_ptr() as *mut _,
-            buf.len(),
-            &mut diskdevno,
-        ))?;
+        c_result(
+            blkid_devno_to_wholedisk(
+                devno,
+                buf.as_mut_ptr() as *mut _,
+                buf.len(),
+                &mut diskdevno,
+            ),
+            "blkid_devno_to_wholedisk",
+        )?;
     }
     let name = unsafe { CStr::from_ptr(buf.as_ptr() as *const _) }
         .to_str()?
@@ -121,11 +124,14 @@ pub fn encode_string(input: &str) -> BlkIdResult<String> {
     let c_input = CString::new(input)?;
     let mut buf = vec![0u8; input.len() * 4 + 1];
     unsafe {
-        c_result(blkid_encode_string(
-            c_input.as_ptr(),
-            buf.as_mut_ptr() as *mut _,
-            buf.len(),
-        ))?;
+        c_result(
+            blkid_encode_string(
+                c_input.as_ptr(),
+                buf.as_mut_ptr() as *mut _,
+                buf.len(),
+            ),
+            "blkid_encode_string",
+        )?;
     }
     let s = unsafe { CStr::from_ptr(buf.as_ptr() as *const _) }
         .to_str()?
@@ -138,11 +144,14 @@ pub fn safe_string(input: &str) -> BlkIdResult<String> {
     let c_input = CString::new(input)?;
     let mut buf = vec![0u8; input.len() + 1];
     unsafe {
-        c_result(blkid_safe_string(
-            c_input.as_ptr(),
-            buf.as_mut_ptr() as *mut _,
-            buf.len(),
-        ))?;
+        c_result(
+            blkid_safe_string(
+                c_input.as_ptr(),
+                buf.as_mut_ptr() as *mut _,
+                buf.len(),
+            ),
+            "blkid_safe_string",
+        )?;
     }
     let s = unsafe { CStr::from_ptr(buf.as_ptr() as *const _) }
         .to_str()?
@@ -170,9 +179,12 @@ pub fn get_library_version() -> (i32, String, String) {
 pub fn parse_version_string(ver: &str) -> BlkIdResult<i32> {
     let c_ver = CString::new(ver)?;
     let code = unsafe { blkid_parse_version_string(c_ver.as_ptr()) };
-    // blkid_parse_version_string returns -1 on error
+    // blkid_parse_version_string returns -1 on error but does not set errno
     if code < 0 {
-        Err(BlkIdError::Io(std::io::Error::last_os_error()))
+        Err(BlkIdError::FfiError {
+            func: "blkid_parse_version_string",
+            errno: std::io::Error::new(std::io::ErrorKind::InvalidInput, "invalid version string"),
+        })
     } else {
         Ok(code)
     }
@@ -182,7 +194,7 @@ pub fn parse_version_string(ver: &str) -> BlkIdResult<i32> {
 pub fn send_uevent(devname: &str, action: &str) -> BlkIdResult<()> {
     let c_devname = CString::new(devname)?;
     let c_action = CString::new(action)?;
-    unsafe { c_result(blkid_send_uevent(c_devname.as_ptr(), c_action.as_ptr())).map(|_| ()) }
+    unsafe { c_result(blkid_send_uevent(c_devname.as_ptr(), c_action.as_ptr()), "blkid_send_uevent").map(|_| ()) }
 }
 
 /// Parse a "NAME=value" tag string. Returns `(name, value)`.
@@ -191,18 +203,23 @@ pub fn parse_tag_string(tag: &str) -> BlkIdResult<(String, String)> {
     let mut ret_type: *mut libc::c_char = ptr::null_mut();
     let mut ret_val: *mut libc::c_char = ptr::null_mut();
     unsafe {
-        c_result(blkid_parse_tag_string(
-            c_tag.as_ptr(),
-            &mut ret_type,
-            &mut ret_val,
-        ))?;
+        c_result(
+            blkid_parse_tag_string(
+                c_tag.as_ptr(),
+                &mut ret_type,
+                &mut ret_val,
+            ),
+            "blkid_parse_tag_string",
+        )?;
     }
-    let name = unsafe { CStr::from_ptr(ret_type).to_str()?.to_owned() };
-    let value = unsafe { CStr::from_ptr(ret_val).to_str()?.to_owned() };
+    let name_bytes = unsafe { CStr::from_ptr(ret_type).to_bytes().to_vec() };
+    let value_bytes = unsafe { CStr::from_ptr(ret_val).to_bytes().to_vec() };
     unsafe {
         libc::free(ret_type as *mut _);
         libc::free(ret_val as *mut _);
     }
+    let name = std::str::from_utf8(&name_bytes)?.to_owned();
+    let value = std::str::from_utf8(&value_bytes)?.to_owned();
     Ok((name, value))
 }
 
@@ -296,7 +313,31 @@ mod tests {
     #[test]
     fn test_devno_to_devname_invalid() {
         // devno 0 should not resolve to a real device
-        assert!(devno_to_devname(0).is_none());
+        let devno: libc::dev_t = 0;
+        assert!(devno_to_devname(devno).is_none());
+    }
+
+    #[test]
+    fn test_encode_string_empty() {
+        let result = encode_string("").unwrap();
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_safe_string_empty() {
+        let result = safe_string("").unwrap();
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_parse_tag_string_empty_value() {
+        // "KEY=" with empty value — libblkid may reject or accept this
+        let result = parse_tag_string("KEY=");
+        // Either it succeeds with empty value or fails; both are acceptable
+        if let Ok((name, value)) = result {
+            assert_eq!(name, "KEY");
+            assert_eq!(value, "");
+        }
     }
 
     #[test]

--- a/src/part_list.rs
+++ b/src/part_list.rs
@@ -18,7 +18,7 @@ impl<'a> PartList<'a> {
     ///
     /// See also [`Self::get_table`].
     pub fn get_partition(&self, part_num: i32) -> BlkIdResult<Partition<'a>> {
-        unsafe { c_result(blkid_partlist_get_partition(self.0, part_num)).map(Partition::new) }
+        unsafe { c_result(blkid_partlist_get_partition(self.0, part_num), "blkid_partlist_get_partition").map(Partition::new) }
     }
 
     /// Returns partition object by the partiton number (e.g. `N` from sda`N`).
@@ -27,7 +27,7 @@ impl<'a> PartList<'a> {
     /// order" partition tables. partition N is located after partition N+1 on the disk.
     #[cfg(blkid = "2.25")]
     pub fn get_partition_by_parno(&self, partno: i32) -> BlkIdResult<Partition<'a>> {
-        unsafe { c_result(blkid_partlist_get_partition_by_partno(self.0, partno)).map(Partition::new) }
+        unsafe { c_result(blkid_partlist_get_partition_by_partno(self.0, partno), "blkid_partlist_get_partition_by_partno").map(Partition::new) }
     }
 
     /// Returns all partitions
@@ -48,8 +48,8 @@ impl<'a> PartList<'a> {
     ///
     /// This function is necessary when you want to make a relation between an entry in the
     /// partition table (list) and block devices in your system.
-    pub fn devno_to_partition(&self, devno: u64) -> BlkIdResult<Partition<'a>> {
-        unsafe { c_result(blkid_partlist_devno_to_partition(self.0, devno)).map(Partition::new) }
+    pub fn devno_to_partition(&self, devno: libc::dev_t) -> BlkIdResult<Partition<'a>> {
+        unsafe { c_result(blkid_partlist_devno_to_partition(self.0, devno), "blkid_partlist_devno_to_partition").map(Partition::new) }
     }
 
     /// Returns [`PartTable`] or `None` if there is not a partition table on the device
@@ -64,6 +64,6 @@ impl<'a> PartList<'a> {
 
     /// Returns number of partitions in the list
     pub fn numof_partitions(&self) -> BlkIdResult<i32> {
-        unsafe { c_result(blkid_partlist_numof_partitions(self.0)) }
+        unsafe { c_result(blkid_partlist_numof_partitions(self.0), "blkid_partlist_numof_partitions") }
     }
 }

--- a/src/part_table.rs
+++ b/src/part_table.rs
@@ -32,7 +32,7 @@ impl<'a> PartTable<'a> {
     /// The position is relative to begin of the device as defined by `Prober::set_device` for
     /// primary partition table, and relative to parental partition for nested partition tables.
     pub fn get_offset(&self) -> BlkIdResult<i64> {
-        unsafe { c_result(blkid_parttable_get_offset(self.0)) }
+        unsafe { c_result(blkid_parttable_get_offset(self.0), "blkid_parttable_get_offset") }
     }
 
     /// Returns parent for nested partition tables

--- a/src/partition.rs
+++ b/src/partition.rs
@@ -29,7 +29,7 @@ impl<'a> Partition<'a> {
     /// Returns proposed partition number (e.g. 'N' from sda'N'). Note that the number is generated
     /// by independently of your OS library.
     pub fn partno(&self) -> BlkIdResult<i32> {
-        unsafe { c_result(blkid_partition_get_partno(self.0)) }
+        unsafe { c_result(blkid_partition_get_partno(self.0), "blkid_partition_get_partno") }
     }
 
     /// Returns size of the partition (in 512-sectors).
@@ -45,7 +45,7 @@ impl<'a> Partition<'a> {
     /// For some unknown reason this (safe) practice is not to used for nested BSD, Solaris, ...,
     /// partition tables in Linux kernel.
     pub fn size(&self) -> BlkIdResult<i64> {
-        unsafe { c_result(blkid_partition_get_size(self.0)) }
+        unsafe { c_result(blkid_partition_get_size(self.0), "blkid_partition_get_size") }
     }
 
     /// Returns start of the partition (in 512-sectors).
@@ -62,7 +62,7 @@ impl<'a> Partition<'a> {
     /// You don't have to care about such details if you probe whole disk. In such a case libblkid
     /// always returns the offset relative to the begin of the disk.
     pub fn start(&self) -> BlkIdResult<i64> {
-        unsafe { c_result(blkid_partition_get_start(self.0)) }
+        unsafe { c_result(blkid_partition_get_start(self.0), "blkid_partition_get_start") }
     }
 
     /// Returns partition table object.
@@ -85,7 +85,7 @@ impl<'a> Partition<'a> {
     /// (partitions within extended partition). It's possible to differentiate between logical,
     /// extended and primary partitions by `Self::is_{extended, primary, logical}`.
     pub fn table(&self) -> BlkIdResult<PartTable<'a>> {
-        unsafe { c_result(blkid_partition_get_table(self.0)).map(PartTable::new) }
+        unsafe { c_result(blkid_partition_get_table(self.0), "blkid_partition_get_table").map(PartTable::new) }
     }
 
     /// Returns partition type

--- a/src/prober.rs
+++ b/src/prober.rs
@@ -50,7 +50,7 @@ impl Drop for Prober {
 impl Prober {
     /// Create newly allocated `probe` struct.
     pub fn new() -> BlkIdResult<Self> {
-        let probe = unsafe { c_result(blkid_new_probe()) }?;
+        let probe = unsafe { c_result(blkid_new_probe(), "blkid_new_probe") }?;
         Ok(Self(probe))
     }
 
@@ -58,7 +58,7 @@ impl Prober {
     /// `filename` can be either regular file or device
     pub fn new_from_filename<P: AsRef<Path>>(filename: P) -> BlkIdResult<Self> {
         let path = path_to_cstring(filename)?;
-        let probe = unsafe { c_result(blkid_new_probe_from_filename(path.as_ptr())) }?;
+        let probe = unsafe { c_result(blkid_new_probe_from_filename(path.as_ptr()), "blkid_new_probe_from_filename") }?;
         Ok(Self(probe))
     }
 
@@ -100,7 +100,10 @@ impl Prober {
         match ret_code {
             0 => Ok(ProbeState::Success),
             1 => Ok(ProbeState::Done),
-            _ => Err(BlkIdError::Io(std::io::Error::last_os_error())),
+            _ => Err(BlkIdError::FfiError {
+                func: "blkid_do_probe",
+                errno: std::io::Error::last_os_error(),
+            }),
         }
     }
 
@@ -128,7 +131,10 @@ impl Prober {
             0 => Ok(ProbeState::Success),
             1 => Ok(ProbeState::NothingDetected),
             -2 => Ok(ProbeState::Ambivalent),
-            _ => Err(BlkIdError::Io(std::io::Error::last_os_error())),
+            _ => Err(BlkIdError::FfiError {
+                func: "blkid_do_safeprobe",
+                errno: std::io::Error::last_os_error(),
+            }),
         }
     }
 
@@ -144,7 +150,10 @@ impl Prober {
         match ret_code {
             0 => Ok(ProbeState::Success),
             1 => Ok(ProbeState::NothingDetected),
-            _ => Err(BlkIdError::Io(std::io::Error::last_os_error())),
+            _ => Err(BlkIdError::FfiError {
+                func: "blkid_do_fullprobe",
+                errno: std::io::Error::last_os_error(),
+            }),
         }
     }
 
@@ -180,7 +189,10 @@ impl Prober {
         match ret_code {
             0 => Ok(ProbeState::Success),
             1 => Ok(ProbeState::Done),
-            _ => Err(BlkIdError::Io(std::io::Error::last_os_error())),
+            _ => Err(BlkIdError::FfiError {
+                func: "blkid_do_wipe",
+                errno: std::io::Error::last_os_error(),
+            }),
         }
     }
 
@@ -197,7 +209,7 @@ impl Prober {
                 &mut name_ptr,
                 &mut data_ptr,
                 &mut len,
-            ))
+            ), "blkid_probe_get_value")
         }?;
 
         let name_value = unsafe { CStr::from_ptr(name_ptr).to_str()?.to_owned() };
@@ -221,7 +233,7 @@ impl Prober {
     /// Check if device has the specified value
     pub fn has_value(&self, name: &str) -> BlkIdResult<bool> {
         let name = CString::new(name)?;
-        unsafe { c_result(blkid_probe_has_value(self.0, name.as_ptr())).map(|val| val == 1) }
+        unsafe { c_result(blkid_probe_has_value(self.0, name.as_ptr()), "blkid_probe_has_value").map(|val| val == 1) }
     }
 
     /// Value by specified `name`
@@ -239,7 +251,7 @@ impl Prober {
                 name.as_ptr(),
                 &mut data_ptr,
                 &mut len,
-            ))
+            ), "blkid_probe_lookup_value")
         }?;
 
         let data_value = unsafe { CStr::from_ptr(data_ptr).to_str()?.to_owned() };
@@ -248,11 +260,11 @@ impl Prober {
 
     /// Number of values in probing result
     pub fn numof_values(&self) -> BlkIdResult<i32> {
-        unsafe { c_result(blkid_probe_numof_values(self.0)) }
+        unsafe { c_result(blkid_probe_numof_values(self.0), "blkid_probe_numof_values") }
     }
 
     /// Block device number, or 0 for regular file
-    pub fn get_devno(&self) -> u64 {
+    pub fn get_devno(&self) -> libc::dev_t {
         unsafe { blkid_probe_get_devno(self.0) }
     }
 
@@ -272,27 +284,27 @@ impl Prober {
     /// before any probing call.
     #[cfg(blkid = "2.30")]
     pub fn set_sector_size(&self, size: u32) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_set_sectorsize(self.0, size)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_set_sectorsize(self.0, size), "blkid_probe_set_sectorsize").map(|_| ()) }
     }
 
     /// 512-byte sector count
     pub fn get_sectors(&self) -> BlkIdResult<i64> {
-        unsafe { c_result(blkid_probe_get_sectors(self.0)) }
+        unsafe { c_result(blkid_probe_get_sectors(self.0), "blkid_probe_get_sectors") }
     }
 
     /// Size of probing area in bytes as defined by [`Self::set_device`]. If the size of the probing
     /// area is unrestricted then this function returns the real size of device
     pub fn get_size(&self) -> BlkIdResult<i64> {
-        unsafe { c_result(blkid_probe_get_size(self.0)) }
+        unsafe { c_result(blkid_probe_get_size(self.0), "blkid_probe_get_size") }
     }
 
     /// Offset of probing area as defined by [`Self::set_device`]
     pub fn get_offset(&self) -> BlkIdResult<i64> {
-        unsafe { c_result(blkid_probe_get_offset(self.0)) }
+        unsafe { c_result(blkid_probe_get_offset(self.0), "blkid_probe_get_offset") }
     }
 
     /// Device number of the wholedisk, or 0 for regular files
-    pub fn get_wholedisk_devno(&self) -> u64 {
+    pub fn get_wholedisk_devno(&self) -> libc::dev_t {
         unsafe { blkid_probe_get_wholedisk_devno(self.0) }
     }
 
@@ -311,7 +323,7 @@ impl Prober {
     /// The [`Self::reset_buffers`] reverts all.
     #[cfg(blkid = "2.31")]
     pub fn hide_range(&self, offset: u64, size: u64) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_hide_range(self.0, offset, size)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_hide_range(self.0, offset, size), "blkid_probe_hide_range").map(|_| ()) }
     }
 
     /// Reuse all already read buffers from the device. The buffers may be modified by
@@ -319,7 +331,7 @@ impl Prober {
     /// will read all data from the device.
     #[cfg(blkid = "2.31")]
     pub fn reset_buffers(&self) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_reset_buffers(self.0)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_reset_buffers(self.0), "blkid_probe_reset_buffers").map(|_| ()) }
     }
 
     /// This function move pointer to the probing chain one step back - it means that the
@@ -339,7 +351,7 @@ impl Prober {
     /// ```
     #[cfg(blkid = "2.23")]
     pub fn step_back(&self) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_step_back(self.0)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_step_back(self.0), "blkid_probe_step_back").map(|_| ()) }
     }
 
     /// Assigns the device to probe control struct, resets internal buffers and resets the current
@@ -350,7 +362,7 @@ impl Prober {
     /// `size`: size of probing area (`None` means whole device/file)
     pub fn set_device(&mut self, fd: i32, offset: i64, size: Option<i64>) -> BlkIdResult<()> {
         let size = size.unwrap_or(0);
-        unsafe { c_result(blkid_probe_set_device(self.0, fd, offset, size)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_set_device(self.0, fd, offset, size), "blkid_probe_set_device").map(|_| ()) }
     }
 
     /// Zeroize probing results and resets the current probing (this has impact to [`Self::do_probe`]
@@ -361,7 +373,7 @@ impl Prober {
 
     /// Enables/disables the superblocks probing for non-binary interface.
     pub fn enable_superblocks(&self, enable: bool) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_enable_superblocks(self.0, enable as i32)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_enable_superblocks(self.0, enable as i32), "blkid_probe_enable_superblocks").map(|_| ()) }
     }
 
     /// If known filesystem type
@@ -374,7 +386,7 @@ impl Prober {
     pub fn superblocks_get_name(idx: usize) -> BlkIdResult<(String, i32)> {
         let mut name: *const ::libc::c_char = ptr::null();
         let mut usage: i32 = 0;
-        unsafe { c_result(blkid_superblocks_get_name(idx, &mut name, &mut usage)) }?;
+        unsafe { c_result(blkid_superblocks_get_name(idx, &mut name, &mut usage), "blkid_superblocks_get_name") }?;
         let name = unsafe { CStr::from_ptr(name).to_str()?.to_owned() };
         Ok((name, usage))
     }
@@ -385,16 +397,22 @@ impl Prober {
         mode: FilterMode,
         names: &[&str],
     ) -> BlkIdResult<()> {
-        let c_names: Vec<CString> = names.iter().map(|n| CString::new(*n).unwrap()).collect();
+        let c_names: Vec<CString> = names
+            .iter()
+            .map(|n| CString::new(*n))
+            .collect::<Result<Vec<_>, _>>()?;
         let mut ptrs: Vec<*mut ::libc::c_char> =
             c_names.iter().map(|c| c.as_ptr() as *mut _).collect();
         ptrs.push(ptr::null_mut());
         unsafe {
-            c_result(blkid_probe_filter_superblocks_type(
-                self.0,
-                mode as i32,
-                ptrs.as_mut_ptr(),
-            ))
+            c_result(
+                blkid_probe_filter_superblocks_type(
+                    self.0,
+                    mode as i32,
+                    ptrs.as_mut_ptr(),
+                ),
+                "blkid_probe_filter_superblocks_type",
+            )
             .map(|_| ())
         }
     }
@@ -410,35 +428,35 @@ impl Prober {
                 self.0,
                 mode as i32,
                 usage.bits(),
-            ))
+            ), "blkid_probe_filter_superblocks_usage")
             .map(|_| ())
         }
     }
 
     /// Inverts superblocks probing filter
     pub fn invert_superblocks_filter(&self) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_invert_superblocks_filter(self.0)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_invert_superblocks_filter(self.0), "blkid_probe_invert_superblocks_filter").map(|_| ()) }
     }
 
     /// Resets superblocks probing filter
     pub fn reset_superblocks_filter(&self) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_reset_superblocks_filter(self.0)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_reset_superblocks_filter(self.0), "blkid_probe_reset_superblocks_filter").map(|_| ()) }
     }
 
     /// Sets probing flags to the superblocks prober. This function is optional, the default are
     /// [`Superblocks::DEFAULT`] flags.
     pub fn set_superblocks_flags(&self, flags: SuperblocksFlags) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_set_superblocks_flags(self.0, flags.bits())).map(|_| ()) }
+        unsafe { c_result(blkid_probe_set_superblocks_flags(self.0, flags.bits()), "blkid_probe_set_superblocks_flags").map(|_| ()) }
     }
 
     /// Enables/disables the partitions probing for non-binary interface
     pub fn enable_partitions(&self, enable: bool) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_enable_partitions(self.0, enable as i32)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_enable_partitions(self.0, enable as i32), "blkid_probe_enable_partitions").map(|_| ()) }
     }
 
     /// Sets probing flags to the partitions prober. This function is optional
     pub fn set_partitions_flags(&self, flags: PartitionsFlags) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_set_partitions_flags(self.0, flags.bits())).map(|_| ()) }
+        unsafe { c_result(blkid_probe_set_partitions_flags(self.0, flags.bits()), "blkid_probe_set_partitions_flags").map(|_| ()) }
     }
 
     /// Filter partitions probing by partition type name.
@@ -447,28 +465,34 @@ impl Prober {
         mode: FilterMode,
         names: &[&str],
     ) -> BlkIdResult<()> {
-        let c_names: Vec<CString> = names.iter().map(|n| CString::new(*n).unwrap()).collect();
+        let c_names: Vec<CString> = names
+            .iter()
+            .map(|n| CString::new(*n))
+            .collect::<Result<Vec<_>, _>>()?;
         let mut ptrs: Vec<*mut ::libc::c_char> =
             c_names.iter().map(|c| c.as_ptr() as *mut _).collect();
         ptrs.push(ptr::null_mut());
         unsafe {
-            c_result(blkid_probe_filter_partitions_type(
-                self.0,
-                mode as i32,
-                ptrs.as_mut_ptr(),
-            ))
+            c_result(
+                blkid_probe_filter_partitions_type(
+                    self.0,
+                    mode as i32,
+                    ptrs.as_mut_ptr(),
+                ),
+                "blkid_probe_filter_partitions_type",
+            )
             .map(|_| ())
         }
     }
 
     /// Inverts partitions probing filter
     pub fn invert_partitions_filter(&self) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_invert_partitions_filter(self.0)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_invert_partitions_filter(self.0), "blkid_probe_invert_partitions_filter").map(|_| ()) }
     }
 
     /// Resets partitions probing filter
     pub fn reset_partitions_filter(&self) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_reset_partitions_filter(self.0)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_reset_partitions_filter(self.0), "blkid_probe_reset_partitions_filter").map(|_| ()) }
     }
 
     /// If known partition table type
@@ -481,7 +505,7 @@ impl Prober {
     #[cfg(blkid = "2.30")]
     pub fn partitions_get_name(idx: usize) -> BlkIdResult<String> {
         let mut name: *const ::libc::c_char = ptr::null();
-        unsafe { c_result(blkid_partitions_get_name(idx.try_into().unwrap(), &mut name)) }?;
+        unsafe { c_result(blkid_partitions_get_name(idx.try_into().unwrap(), &mut name), "blkid_partitions_get_name") }?;
         let name = unsafe { CStr::from_ptr(name).to_str()?.to_owned() };
         Ok(name)
     }
@@ -498,12 +522,12 @@ impl Prober {
     /// prober. If you want to use more [`PartList`] objects in the same time you have to create
     /// more [`Prober`] handlers.
     pub fn part_list(&self) -> BlkIdResult<PartList<'_>> {
-        unsafe { c_result(blkid_probe_get_partitions(self.0)).map(PartList::new) }
+        unsafe { c_result(blkid_probe_get_partitions(self.0), "blkid_probe_get_partitions").map(PartList::new) }
     }
 
     /// Enables/disables the topology probing for non-binary interface
     pub fn enable_topology(&self, enable: bool) -> BlkIdResult<()> {
-        unsafe { c_result(blkid_probe_enable_topology(self.0, enable as i32)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_enable_topology(self.0, enable as i32), "blkid_probe_enable_topology").map(|_| ()) }
     }
 
     /// Returns topology.
@@ -518,7 +542,7 @@ impl Prober {
     /// prober. If you want to use more [`Topology`] objects in the same time you have to create
     /// more [`Prober`] handlers.
     pub fn topology(&self) -> BlkIdResult<Topology<'_>> {
-        unsafe { c_result(blkid_probe_get_topology(self.0)).map(Topology::new) }
+        unsafe { c_result(blkid_probe_get_topology(self.0), "blkid_probe_get_topology").map(Topology::new) }
     }
 
     /// Sets extra hint for low-level prober. If the hint is set by NAME=value notation than value
@@ -529,7 +553,7 @@ impl Prober {
     #[cfg(blkid = "2.37")]
     pub fn set_hint(&self, hint_name: &str, offset: u64) -> BlkIdResult<()> {
         let name = CString::new(hint_name)?;
-        unsafe { c_result(blkid_probe_set_hint(self.0, name.as_ptr(), offset)).map(|_| ()) }
+        unsafe { c_result(blkid_probe_set_hint(self.0, name.as_ptr(), offset), "blkid_probe_set_hint").map(|_| ()) }
     }
 
     /// Removes all previously defined probing hints. See also [`Self::set_hint`]

--- a/src/prober.rs
+++ b/src/prober.rs
@@ -505,7 +505,7 @@ impl Prober {
     #[cfg(blkid = "2.30")]
     pub fn partitions_get_name(idx: usize) -> BlkIdResult<String> {
         let mut name: *const ::libc::c_char = ptr::null();
-        unsafe { c_result(blkid_partitions_get_name(idx.try_into().unwrap(), &mut name), "blkid_partitions_get_name") }?;
+        unsafe { c_result(blkid_partitions_get_name(idx, &mut name), "blkid_partitions_get_name") }?;
         let name = unsafe { CStr::from_ptr(name).to_str()?.to_owned() };
         Ok(name)
     }

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -13,27 +13,27 @@ impl<'a> Topology<'a> {
 
     /// Alignment offset in bytes or 0.
     pub fn alignment_offset(&self) -> u64 {
-        unsafe { blkid_topology_get_alignment_offset(self.0) }.try_into().unwrap()
+        unsafe { blkid_topology_get_alignment_offset(self.0) as u64 }
     }
 
     /// Minimum io size in bytes or 0.
     pub fn minimum_io_size(&self) -> u64 {
-        unsafe { blkid_topology_get_minimum_io_size(self.0) }.try_into().unwrap()
+        unsafe { blkid_topology_get_minimum_io_size(self.0) as u64 }
     }
 
     /// Optimal io size in bytes or 0.
     pub fn optimal_io_size(&self) -> u64 {
-        unsafe { blkid_topology_get_optimal_io_size(self.0) }.try_into().unwrap()
+        unsafe { blkid_topology_get_optimal_io_size(self.0) as u64 }
     }
 
     /// Logical sector size (BLKSSZGET ioctl) in bytes or 0.
     pub fn logical_sector_size(&self) -> u64 {
-        unsafe { blkid_topology_get_logical_sector_size(self.0) }.try_into().unwrap()
+        unsafe { blkid_topology_get_logical_sector_size(self.0) as u64 }
     }
 
     /// Logical sector size (BLKSSZGET ioctl) in bytes or 0.
     pub fn physical_sector_size(&self) -> u64 {
-        unsafe { blkid_topology_get_physical_sector_size(self.0) }.try_into().unwrap()
+        unsafe { blkid_topology_get_physical_sector_size(self.0) as u64 }
     }
 
     /// Returns `true` if dax is supported

--- a/tests/ui/devs_outlives_cache.rs
+++ b/tests/ui/devs_outlives_cache.rs
@@ -7,7 +7,7 @@ fn main() {
     let devs = {
         let cache = Cache::new().unwrap();
         cache.probe_all().unwrap();
-        cache.devs()
+        cache.devs().unwrap()
     };
     // cache is dropped here, but devs still references it — must not compile
     for dev in devs {

--- a/tests/ui/devs_outlives_cache.stderr
+++ b/tests/ui/devs_outlives_cache.stderr
@@ -6,7 +6,7 @@ error[E0597]: `cache` does not live long enough
  8 |         let cache = Cache::new().unwrap();
    |             ----- binding `cache` declared here
  9 |         cache.probe_all().unwrap();
-10 |         cache.devs()
+10 |         cache.devs().unwrap()
    |         ^^^^^ borrowed value does not live long enough
 11 |     };
    |     - `cache` dropped here while still borrowed


### PR DESCRIPTION
Add FfiError variant to BlkIdError that includes the FFI function name in error messages, replacing opaque "No such file or directory (os error 2)" errors with e.g. "blkid_do_probe: Permission denied (os error 13)".

Bug fixes:
- Fix find_tag_value memory leak (missing libc::free)
- Fix parse_tag_string leak on UTF-8 error (free before checking)
- Fix evaluate_tag/evaluate_spec dangling cache pointer (use null_mut)
- Fix parse_version_string using stale errno (use InvalidInput)
- Fix filter_*_type panics on interior NUL (replace unwrap with ?)
- Fix get_devname silently swallowing NUL errors (return BlkIdResult)
- Fix devno_to_wholedisk undersized buffer (128 -> 4096)
- Use libc::dev_t instead of u64 for device number parameters
- Remove unnecessary extern crate libc